### PR TITLE
Used release version from model to construct quick start guide

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -2,7 +2,7 @@
   <i class="icon-attention-circled"></i>
   <strong>Getting Started?</strong> Ember-CLI is the
   modern, supported way to run an Ember application.
-  <a class="btn" href="https://guides.emberjs.com/v2.4.0/getting-started/quick-start/">Getting Started Guide</a>
+  <a class="btn" href={{concat 'https://guides.emberjs.com/v' model.release.lastRelease '/getting-started/quick-start/'}}>Getting Started Guide</a>
 </div>
 
 <p>


### PR DESCRIPTION
Link to quick start guide is no longer hard coded.

Fixes #2628