### PR TITLE
Fix release cycle showing wrong next beta date

### DIFF
--- a/app/templates/components/project-listing/beta.hbs
+++ b/app/templates/components/project-listing/beta.hbs
@@ -4,5 +4,5 @@
   <div class="beta-current-version">(current beta)</div>
 {{/if}}
 {{#if isFutureBeta}}
-  <div class="beta-current-version">({{format-date-time project.nextDate "MMM Do"}})</div>
+  <div class="beta-current-version">({{format-date-time nextDate "MMM Do"}})</div>
 {{/if}}

--- a/app/templates/components/release-timeline.hbs
+++ b/app/templates/components/release-timeline.hbs
@@ -16,30 +16,35 @@
         isCompleted=project.beta2Completed
         isCurrentBeta=project.isBeta2
         isFutureBeta=project.isBeta1
+        nextDate=project.nextDate
     }}
     {{project-listing/beta
         version=3
         isCompleted=project.beta3Completed
         isCurrentBeta=project.isBeta3
         isFutureBeta=project.isBeta2
+        nextDate=project.nextDate
     }}
     {{project-listing/beta
         version=4
         isCompleted=project.beta4Completed
         isCurrentBeta=project.isBeta4
         isFutureBeta=project.isBeta3
+        nextDate=project.nextDate
     }}
     {{project-listing/beta
         version=5
         isCompleted=project.beta5Completed
         isCurrentBeta=project.isBeta5
         isFutureBeta=project.isBeta4
+        nextDate=project.nextDate
     }}
     {{project-listing/beta
         version=6
         isCompleted=project.beta6Completed
         isCurrentBeta=project.isBeta6
         isFutureBeta=project.isBeta5
+        nextDate=project.nextDate
     }}
   </div>
   <div class="right future-image">


### PR DESCRIPTION
The project-listing/beta component expected to be able to access `project.nextDate`, but `project` is never passed to it.
Fixed the bug, so that now the component receives the right date.