### PR TITLE
Fix date on release build

### DIFF
--- a/app/data/ember/release.js
+++ b/app/data/ember/release.js
@@ -8,7 +8,7 @@ export default {
   lastRelease: "2.12.0",
   futureVersion: "2.12.1",
   channel: "release",
-  date: "2017-04-24",
+  date: "2017-03-19",
   changelogPath: "CHANGELOG.md",
   enableTestURL: true,
   debugFileName: ".debug.js",

--- a/app/data/ember/release.js
+++ b/app/data/ember/release.js
@@ -8,7 +8,7 @@ export default {
   lastRelease: "2.12.0",
   futureVersion: "2.12.1",
   channel: "release",
-  date: "2017-03-19",
+  date: "2017-03-15",
   changelogPath: "CHANGELOG.md",
   enableTestURL: true,
   debugFileName: ".debug.js",


### PR DESCRIPTION
It's set to the date of the release blogpost. Maybe it should be the same as initialReleaseDate?