### PR TITLE
fix(builds): adds polyfill for es6 features in ie11

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,10 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
-    vendorFiles: { 'jquery.js': null }
+    vendorFiles: { 'jquery.js': null },
+    'ember-cli-babel': {
+      includePolyfill: true,
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
<img width="1123" alt="screen shot 2018-04-01 at 00 46 07" src="https://user-images.githubusercontent.com/8811742/38168205-6340df26-3546-11e8-8216-f7d1fb3c4987.png">

From the [ember-cli-babel](https://github.com/babel/ember-cli-babel#polyfill) documentation:

> Babel comes with a polyfill that includes a custom regenerator runtime and core-js. Many transformations will work without it, but for full support you may need to include the polyfill in your app.
>
> To include it in your app, pass includePolyfill: true in your ember-cli-babel options.

I included the babel polyfill into the app.
This seems to resolve the issue of features like `Symbol` being `undefined` in Internet Explorer - tested on a Windows7 VirtualBox on IE11. 

Closes #82 and [emberjs/website#3253](https://github.com/emberjs/website/issues/3253)
