### PR TITLE
table layout hotfix

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -38,7 +38,7 @@
   (30 weeks).
 </p>
 
-<table class="lts-schedule">
+<table class="lts-schedule table">
   <thead>
     <tr>
       <th colspan="4">


### PR DESCRIPTION
jkarsrud noted that the builds app table had bad/no styling:

![screen shot 2018-11-30 at 9 47 41 am](https://user-images.githubusercontent.com/16627268/49295941-fe0e2380-f484-11e8-9b48-8d3361984e1b.png)

Locally, it looked like this:
![screen shot 2018-11-30 at 9 50 25 am](https://user-images.githubusercontent.com/16627268/49296124-68bf5f00-f485-11e8-94e2-ffa6eca6e05d.png)

jkarsrud suggested that by adding the `table` class, it looks better:

![screen shot 2018-11-30 at 9 52 16 am](https://user-images.githubusercontent.com/16627268/49296217-a58b5600-f485-11e8-80c6-0881edf8698e.png)
